### PR TITLE
V0.3.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # mkfat
 
+## 0.3.0
+
+* Enhancements
+  * Files can be a string filename or an object with in / out
+    A string is intrepreted as `{"in": "<string>"}`
+
 ## 0.2.0
 
 * Enhancements

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -296,7 +296,7 @@ checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
 name = "mkfat"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "clap",
  "fatfs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mkfat"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = "A tool to create FAT filesystem images from a JSON manifest."
 homepage = "https://github.com/avocado-linux/mkfat"

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -42,6 +42,41 @@ fn test_mkfat_integration() {
 }
 
 #[test]
+fn test_mkfat_integration_string_entry() {
+    let temp_dir = tempdir().unwrap();
+    let base_path = temp_dir.path();
+
+    let manifest_path = base_path.join("boot.json");
+    let output_path = base_path.join("test.fat");
+    let file_to_include_path = base_path.join("hello.txt");
+    fs::write(&file_to_include_path, "Hello, world!").unwrap();
+
+    let manifest_content = r#"{
+        "files": [
+            "hello.txt"
+        ]
+    }"#;
+    fs::write(&manifest_path, manifest_content).unwrap();
+
+    let status = Command::new(env!("CARGO_BIN_EXE_mkfat"))
+        .arg("--manifest")
+        .arg(&manifest_path)
+        .arg("--base")
+        .arg(&base_path)
+        .arg("--output")
+        .arg(&output_path)
+        .arg("--size-mb")
+        .arg("128")
+        .arg("--label")
+        .arg("BOOT")
+        .status()
+        .expect("Failed to execute command");
+
+    assert!(status.success());
+    assert!(output_path.exists());
+}
+
+#[test]
 fn test_mkfat_integration_stdin() {
     let temp_dir = tempdir().unwrap();
     let base_path = temp_dir.path();


### PR DESCRIPTION
* Enhancements
  * Files can be a string filename or an object with in / out
    A string is intrepreted as `{"in": "<string>"}`