### PR TITLE
0.4.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # mkfat
 
+## 0.4.0
+
+* Enhancements
+  * Changed `--fat-type` to `--variant`
+  * Updated variants to `fat12|fat16|fat32`
+  * Added support for parsing variant from `<manifest>.build_args.variant`
+  * Moved the `files` key to `<manifest>.build_args.files`
+
 ## 0.3.0
 
 * Enhancements

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -296,7 +296,7 @@ checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
 name = "mkfat"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "clap",
  "fatfs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mkfat"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 description = "A tool to create FAT filesystem images from a JSON manifest."
 homepage = "https://github.com/avocado-linux/mkfat"

--- a/README.md
+++ b/README.md
@@ -14,35 +14,41 @@ mkfat --manifest <manifest.json> --base <base_path> --output <image.fat>
 | --- | --- | --- | --- |
 | `--manifest` | `-m` | JSON file describing the files and directories to include | |
 | `--base` | `-b` | Base path to find source files | |
-| `--output` | `-o` | Output path for the generated FAT image | |
+| `--output` | `-o` | Output path for the generated FAT image. Overrides manifest `out`. | |
 | `--size-mb` | `-s` | Size of the image in MB | 16 |
 | `--label` | `-l` | Set the volume label | FATFS |
-| `--fat-type` | | Set the FAT type (`fat12`, `fat16`, `fat32`) | `fat32` |
+| `--variant` | | Set the filesystem variant (`FAT12`, `FAT16`, `FAT32`). Overrides manifest `build_args.variant`. | |
 | `--verbose` | `-v` | Verbose output | |
 | `--quiet` | `-q` | Quiet output | |
 
 ## Manifest Format
 
-The manifest is a JSON file that describes the contents of the FAT image. It has two main keys: `files` and `directories`.
+The manifest is a JSON file that describes the contents of the FAT image. Top-level keys:
 
-*   `files`: A list of file entries to include in the image. Each entry is an object with the following keys:
-    *   `filename`: The path to the source file, relative to the `base` path.
-    *   `output`: The path where the file will be placed in the FAT image. If omitted, the `filename` path is used.
+*   `build_args`: Contains build-related configuration.
+    *   `files`: A list of file entries to include in the image. Each entry can be either a string or an object with keys:
+        *   `in`: The path to the source file, relative to the `base` path.
+        *   `out`: The target path inside the FAT image. If omitted, the `in` path is used.
+    *   `variant`: Optional string, one of `FAT12`, `FAT16`, `FAT32`. Maps to the filesystem type.
+*   `out`: Optional filename for the generated image. If provided and `--output` is not used, the image will be written to `<base>/<out>`.
 *   `directories`: An optional list of empty directories to create in the image.
 
 ### Example Manifest
 
 ```json
 {
-  "files": [
-    {
-      "filename": "data/hello.txt",
-      "output": "greeting/hello.txt"
-    },
-    {
-      "filename": "data/another.txt"
-    }
-  ],
+  "build_args": {
+    "files": [
+      {
+        "in": "data/hello.txt",
+        "out": "greeting/hello.txt"
+      },
+      {
+        "in": "data/another.txt"
+      }
+    ]
+  },
+  "out": "my_image.fat",
   "directories": [
     "empty_dir",
     "another_dir/subdir"
@@ -64,15 +70,18 @@ The manifest is a JSON file that describes the contents of the FAT image. It has
 
     ```json
     {
-      "files": [
-        {
-          "filename": "data/hello.txt",
-          "output": "greeting/hello.txt"
-        },
-        {
-          "filename": "data/another.txt"
-        }
-      ],
+      "build_args": {
+        "files": [
+          {
+            "in": "data/hello.txt",
+            "out": "greeting/hello.txt"
+          },
+          {
+            "in": "data/another.txt"
+          }
+        ]
+      },
+      "out": "my_image.fat",
       "directories": [
         "empty_dir"
       ]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -14,12 +14,15 @@ fn test_mkfat_integration() {
     fs::write(&file_to_include_path, "Hello, world!").unwrap();
 
     let manifest_content = r#"{
-        "files": [
-            {
-                "in": "hello.txt",
-                "out": "greeting/hello.txt"
-            }
-        ]
+        "build_args": {
+            "files": [
+                {
+                    "in": "hello.txt",
+                    "out": "greeting/hello.txt"
+                }
+            ]
+        },
+        "out": "test.fat"
     }"#;
     fs::write(&manifest_path, manifest_content).unwrap();
 
@@ -52,9 +55,12 @@ fn test_mkfat_integration_string_entry() {
     fs::write(&file_to_include_path, "Hello, world!").unwrap();
 
     let manifest_content = r#"{
-        "files": [
-            "hello.txt"
-        ]
+        "build_args": {
+            "files": [
+                "hello.txt"
+            ]
+        },
+        "out": "test.fat"
     }"#;
     fs::write(&manifest_path, manifest_content).unwrap();
 
@@ -86,12 +92,15 @@ fn test_mkfat_integration_stdin() {
     fs::write(&file_to_include_path, "Hello, stdin!").unwrap();
 
     let manifest_content = r#"{
-        "files": [
-            {
-                "in": "hello_stdin.txt",
-                "out": "greeting/hello.txt"
-            }
-        ]
+        "build_args": {
+            "files": [
+                {
+                    "in": "hello_stdin.txt",
+                    "out": "greeting/hello.txt"
+                }
+            ]
+        },
+        "out": "test_stdin.fat"
     }"#;
 
     let mut child = Command::new(env!("CARGO_BIN_EXE_mkfat"))
@@ -118,4 +127,97 @@ fn test_mkfat_integration_stdin() {
 
     assert!(status.success());
     assert!(output_path.exists());
+}
+
+#[test]
+fn test_cli_overrides_manifest_out() {
+    let temp_dir = tempdir().unwrap();
+    let base_path = temp_dir.path();
+
+    let manifest_path = base_path.join("boot.json");
+    let cli_output_path = base_path.join("cli_out.fat");
+    let manifest_output_path = base_path.join("manifest_out.fat");
+    let file_to_include_path = base_path.join("hello.txt");
+    fs::write(&file_to_include_path, "Hello, world!").unwrap();
+
+    let manifest_content = r#"{
+        "build_args": {
+            "files": [
+                {
+                    "in": "hello.txt",
+                    "out": "greeting/hello.txt"
+                }
+            ]
+        },
+        "out": "manifest_out.fat"
+    }"#;
+    fs::write(&manifest_path, manifest_content).unwrap();
+
+    let status = Command::new(env!("CARGO_BIN_EXE_mkfat"))
+        .arg("--manifest")
+        .arg(&manifest_path)
+        .arg("--base")
+        .arg(&base_path)
+        .arg("--output")
+        .arg(&cli_output_path)
+        .arg("--size-mb")
+        .arg("16")
+        .arg("--label")
+        .arg("OVERRIDE")
+        .status()
+        .expect("Failed to execute command");
+
+    assert!(status.success());
+    assert!(cli_output_path.exists());
+    assert!(!manifest_output_path.exists());
+}
+
+#[test]
+fn test_cli_overrides_manifest_variant() {
+    use std::fs::File;
+    use std::io::{Read, Seek, SeekFrom};
+
+    let temp_dir = tempdir().unwrap();
+    let base_path = temp_dir.path();
+
+    let manifest_path = base_path.join("boot.json");
+    let output_path = base_path.join("variant_override.fat");
+    let file_to_include_path = base_path.join("hello.txt");
+    fs::write(&file_to_include_path, "Hello, world!").unwrap();
+
+    // Manifest requests FAT16, but CLI will force FAT32
+    let manifest_content = r#"{
+        "build_args": {
+            "files": [
+                "hello.txt"
+            ],
+            "variant": "FAT16"
+        },
+        "out": "variant_override.fat"
+    }"#;
+    fs::write(&manifest_path, manifest_content).unwrap();
+
+    let status = Command::new(env!("CARGO_BIN_EXE_mkfat"))
+        .arg("--manifest")
+        .arg(&manifest_path)
+        .arg("--base")
+        .arg(&base_path)
+        .arg("--variant")
+        .arg("FAT32")
+        .arg("--verbose")
+        .status()
+        .expect("Failed to execute command");
+
+    assert!(status.success());
+    assert!(output_path.exists());
+
+    // Verify the volume label area contains spaces and that we can read the boot sector without UTF8 errors.
+    // We avoid relying on exact FAT type signature offsets which may vary by formatter.
+    let mut f = File::open(&output_path).expect("failed to open image");
+    let mut boot_sector = [0u8; 512];
+    f.seek(SeekFrom::Start(0)).expect("seek failed");
+    f.read_exact(&mut boot_sector).expect("read failed");
+    // Check the BIOS Parameter Block signature 0x55AA at the end of sector
+    assert_eq!(boot_sector[510], 0x55);
+    assert_eq!(boot_sector[511], 0xAA);
 }


### PR DESCRIPTION
* Enhancements
  * Changed `--fat-type` to `--variant`
  * Updated variants to `fat12|fat16|fat32`
  * Added support for parsing variant from `<manifest>.build_args.variant`
  * Moved the `files` key to `<manifest>.build_args.files`